### PR TITLE
Count a multibyte char width as 2 chars width

### DIFF
--- a/lib/text-table.rb
+++ b/lib/text-table.rb
@@ -1,3 +1,4 @@
+$KCODE = 'u'
 %w(table row cell enumerable symbol).each do |lib|
   require File.join(File.dirname(__FILE__), 'text-table', lib)
 end

--- a/lib/text-table/cell.rb
+++ b/lib/text-table/cell.rb
@@ -5,7 +5,7 @@ module Text #:nodoc:
       # The object whose <tt>to_s</tt> method is called when rendering the cell.
       #
       attr_accessor :value
-      
+
       # Text alignment.  Acceptable values are <tt>:left</tt> (default),
       # <tt>:center</tt> and <tt>:right</tt>
       #
@@ -21,6 +21,10 @@ module Text #:nodoc:
         @row     = options[:row]
         @align   = options[:align  ] || :left
         @colspan = options[:colspan] || 1
+      end
+
+      def text_width
+        value.length + value.chars.count { |c| c.bytesize > 2 }
       end
 
       def to_s #:nodoc:
@@ -43,7 +47,7 @@ module Text #:nodoc:
       end
 
       def cell_width #:nodoc:
-        (0...colspan).map {|i| table.column_widths[column_index + i]}.inject(&:+) + (colspan - 1)*(2*table.horizontal_padding + table.horizontal_boundary.length)
+        (0...colspan).map {|i| table.column_widths[column_index + i]}.inject(&:+) + (colspan - 1)*(2*table.horizontal_padding + table.horizontal_boundary.length) - text_width + value.length
       end
 
     end

--- a/lib/text-table/cell.rb
+++ b/lib/text-table/cell.rb
@@ -24,17 +24,27 @@ module Text #:nodoc:
       end
 
       def text_width
-        value.length + value.chars.count { |c| c.bytesize > 2 }
+        char_count + value.chars.count { |c| c.bytesize > 2 }
+      end
+
+      def char_count
+        @char_count ||= value.split('').length
       end
 
       def to_s #:nodoc:
+        if RUBY_VERSION < '1.9'
+          len = value.bytesize + cell_width - text_width
+        else
+          len = value.length + cell_width - text_width
+        end
+
       ([' ' * table.horizontal_padding]*2).join case align
         when :left
-          value.ljust cell_width
+          value.ljust len
         when :right
-          value.rjust cell_width
+          value.rjust len
         when :center
-          value.center cell_width
+          value.center len
         end
       end
 
@@ -47,7 +57,7 @@ module Text #:nodoc:
       end
 
       def cell_width #:nodoc:
-        (0...colspan).map {|i| table.column_widths[column_index + i]}.inject(&:+) + (colspan - 1)*(2*table.horizontal_padding + table.horizontal_boundary.length) - text_width + value.length
+        (0...colspan).map {|i| table.column_widths[column_index + i]}.inject(&:+) + (colspan - 1)*(2*table.horizontal_padding + table.horizontal_boundary.length)
       end
 
     end

--- a/lib/text-table/table.rb
+++ b/lib/text-table/table.rb
@@ -153,7 +153,7 @@ module Text #:nodoc:
     def column_widths #:nodoc:
       @column_widths ||= \
       all_text_table_rows.reject {|row| row.cells == :separator}.map do |row|
-        row.cells.map {|cell| [(cell.value.length/cell.colspan.to_f).ceil] * cell.colspan}.flatten
+        row.cells.map {|cell| [(cell.text_width/cell.colspan.to_f).ceil] * cell.colspan}.flatten
       end.transpose.map(&:max)
     end
 

--- a/spec/integration/multibyte_spec.rb
+++ b/spec/integration/multibyte_spec.rb
@@ -1,0 +1,26 @@
+require 'integration_helper'
+
+describe Text::Table do
+  let(:table) { Text::Table.new :rows => rows }
+  let(:rows) do
+    [
+      %w(Hello),
+      %w(こんにちは),
+      %w(مرحبا),
+      %w(안녕하세요),
+    ]
+  end
+
+  subject { table.to_s }
+
+  describe 'rows' do
+    it { should == deindent(%q{
+      +------------+
+      | Hello      |
+      | こんにちは |
+      | مرحبا      |
+      | 안녕하세요 |
+      +------------+
+    }) }
+  end
+end

--- a/spec/integration/multibyte_spec.rb
+++ b/spec/integration/multibyte_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'integration_helper'
 
 describe Text::Table do

--- a/spec/integration/multibyte_spec.rb
+++ b/spec/integration/multibyte_spec.rb
@@ -4,10 +4,10 @@ describe Text::Table do
   let(:table) { Text::Table.new :rows => rows }
   let(:rows) do
     [
-      %w(Hello),
-      %w(こんにちは),
-      %w(مرحبا),
-      %w(안녕하세요),
+      ["Hello"],
+      ["こんにちは"],
+      ["مرحبا"],
+      ["안녕하세요"],
     ]
   end
 


### PR DESCRIPTION
Current code uses the number of characters as a text width, so that a table rows which includes multibyte characters have different width. If we put 3 byte characters to be 2 times wider than ascii characters, a table rows have same width on monospaced font.

![text-table-multibyte](https://cloud.githubusercontent.com/assets/1140583/10666964/b9d78402-790f-11e5-996b-6544012830de.png)
